### PR TITLE
Fix missing factor of -2 in SUBVPSE diffusion coeff

### DIFF
--- a/flowfusion/diffusion.py
+++ b/flowfusion/diffusion.py
@@ -1139,7 +1139,7 @@ class SUBVPSDE(torch.nn.Module):
         beta_min=0.1,
         beta_max=20,
         T=1.0,
-        epsilon=1e-5,
+        epsilon=1e-3,
     ):
         """
         Parameters
@@ -1229,8 +1229,8 @@ class SUBVPSDE(torch.nn.Module):
             * (
                 1.0
                 - torch.exp(
-                    self.beta_min * t
-                    + 0.5 * (self.beta_max - self.beta_min) * t**2 / self.T
+                    - 2 * self.beta_min * t
+                    - (self.beta_max - self.beta_min) * t**2 / self.T
                 )
             )
         ).view(-1, *[1] * len(dims))


### PR DESCRIPTION
Fixes #12.

Basically what it says in the title. I audited the `SUBVPSDE` class, per @gurjeetjagwani's suggestion in #12, and found a missing factor of $-2$ in the SDE diffusion coefficient. Everything else in that class looks fine. I fixed the diffusion term and changed the default `epsilon` to be 1e-3 for consistency with the `VPSDE`.

I ran the demo notebook with the modified `SUBVPSDE` class in place of `VESDE` and it worked pretty well!